### PR TITLE
Fix #19 - Correctly handle position fixes out of time sequence.

### DIFF
--- a/parseigc.js
+++ b/parseigc.js
@@ -141,9 +141,9 @@ function parseIGC(igcFile) {
             var positionTime = new Date(flightDate.getTime());
             positionTime.setUTCHours(parseInt(positionMatch[1], 10), parseInt(positionMatch[2], 10), parseInt(positionMatch[3], 10));
             // If the flight crosses midnight (UTC) then we now have a time that is 24 hours out.
-            // We know that this is the case if the time is earlier than the one for the previous position fix.
+            // We know that this is the case if the time is earlier than the first position fix.
             if (model.recordTime.length > 0 &&
-                model.recordTime[model.recordTime.length - 1] > positionTime) {
+                model.recordTime[0] > positionTime) {
                 positionTime.setDate(flightDate.getDate() + 1);
             }
 


### PR DESCRIPTION
Hi Richard,

Here is a possible fix for the problem that you found in 5AA_WPP.igc. If we assume that the flight never lasts more than 24 hours then compare against the first fix (instead of the previous fix) to determine whether the flight has crossed midnight.

The viewer no longer gets confused by the times appearing out of sequence, although the GPS height line dips to zero in the places where only a 2D fix was available.
