### PR TITLE
Fix bug with cross-hair position on resizing graph (issue #14)

### DIFF
--- a/lib/jquery.flot.crosshair.js
+++ b/lib/jquery.flot.crosshair.js
@@ -1,6 +1,7 @@
-/* Flot plugin for showing crosshairs when the mouse hovers over the plot.
+/* Flot plugin for showing crosshairs on the plot.
 
-Copyright (c) 2007-2014 IOLA and Ole Laursen.
+Copyright (c) 2007-2014 IOLA and Ole Laursen,
+2015 Alistair Green.
 Licensed under the MIT license.
 
 The plugin supports these options:
@@ -17,48 +18,21 @@ horizontal crosshair and "xy" enables them both. "color" is the color of the
 crosshair (default is "rgba(170, 0, 0, 0.80)"), "lineWidth" is the width of
 the drawn lines (default is 1).
 
-The plugin also adds four public methods:
+The plugin also adds one public method:
 
-  - setCrosshair( pos )
+  - lockCrosshair( pos )
 
-    Set the position of the crosshair. Note that this is cleared if the user
-    moves the mouse. "pos" is in coordinates of the plot and should be on the
+    Set the position of the crosshair.
+    "pos" is in coordinates of the plot and should be on the
     form { x: xpos, y: ypos } (you can use x2/x3/... if you're using multiple
     axes), which is coincidentally the same format as what you get from a
     "plothover" event. If "pos" is null, the crosshair is cleared.
 
-  - clearCrosshair()
-
-    Clear the crosshair.
-
-  - lockCrosshair(pos)
-
-    Cause the crosshair to lock to the current location, no longer updating if
-    the user moves the mouse. Optionally supply a position (passed on to
-    setCrosshair()) to move it to.
-
-    Example usage:
-
-	var myFlot = $.plot( $("#graph"), ..., { crosshair: { mode: "x" } } };
-	$("#graph").bind( "plothover", function ( evt, position, item ) {
-		if ( item ) {
-			// Lock the crosshair to the data point being hovered
-			myFlot.lockCrosshair({
-				x: item.datapoint[ 0 ],
-				y: item.datapoint[ 1 ]
-			});
-		} else {
-			// Return normal crosshair operation
-			myFlot.unlockCrosshair();
-		}
-	});
-
-  - unlockCrosshair()
-
-    Free the crosshair to move again after locking it.
 */
 
 (function ($) {
+    'use strict';
+    
     var options = {
         crosshair: {
             mode: null, // one of null, "x", "y" or "xy",
@@ -68,77 +42,42 @@ The plugin also adds four public methods:
     };
     
     function init(plot) {
-        // position of crosshair in pixels
-        var crosshair = { x: -1, y: -1, locked: false };
+        // position of crosshair in axis units
+        var crosshair = { x: null, y: null };
 
-        plot.setCrosshair = function setCrosshair(pos) {
-            if (!pos)
-                crosshair.x = -1;
+        plot.lockCrosshair = function lockCrosshair(pos) {
+            if (pos) {
+                crosshair.x = pos.x;
+                crosshair.y = pos.y;
+            }
             else {
-                var o = plot.p2c(pos);
-                crosshair.x = Math.max(0, Math.min(o.left, plot.width()));
-                crosshair.y = Math.max(0, Math.min(o.top, plot.height()));
+                crosshair.x = null;
+                crosshair.y = null;
             }
             
             plot.triggerRedrawOverlay();
         };
-        
-        plot.clearCrosshair = plot.setCrosshair; // passes null for pos
-        
-        plot.lockCrosshair = function lockCrosshair(pos) {
-            if (pos)
-                plot.setCrosshair(pos);
-            crosshair.locked = true;
-        };
-
-        plot.unlockCrosshair = function unlockCrosshair() {
-            crosshair.locked = false;
-        };
-
-        function onMouseOut(e) {
-            if (crosshair.locked)
-                return;
-
-            if (crosshair.x != -1) {
-                crosshair.x = -1;
-                plot.triggerRedrawOverlay();
-            }
-        }
-
-        function onMouseMove(e) {
-            if (crosshair.locked)
-                return;
-                
-            if (plot.getSelection && plot.getSelection()) {
-                crosshair.x = -1; // hide the crosshair while selecting
-                return;
-            }
-                
-            var offset = plot.offset();
-            crosshair.x = Math.max(0, Math.min(e.pageX - offset.left, plot.width()));
-            crosshair.y = Math.max(0, Math.min(e.pageY - offset.top, plot.height()));
-            plot.triggerRedrawOverlay();
-        }
-        
-        plot.hooks.bindEvents.push(function (plot, eventHolder) {
-            if (!plot.getOptions().crosshair.mode)
-                return;
-
-            eventHolder.mouseout(onMouseOut);
-            eventHolder.mousemove(onMouseMove);
-        });
 
         plot.hooks.drawOverlay.push(function (plot, ctx) {
             var c = plot.getOptions().crosshair;
-            if (!c.mode)
+            if (!c.mode) {
                 return;
+            }
 
             var plotOffset = plot.getPlotOffset();
             
             ctx.save();
             ctx.translate(plotOffset.left, plotOffset.top);
 
-            if (crosshair.x != -1) {
+            if (crosshair.x !== null && crosshair.y !== null) {
+                // Convert logical position to pixels. Have to do this
+                // at draw time to cope with resizing.
+                var o = plot.p2c(crosshair);
+                var pixelPos = {
+                    x: Math.max(0, Math.min(o.left, plot.width())),
+                    y: Math.max(0, Math.min(o.top, plot.height()))
+                };
+                
                 var adj = plot.getOptions().crosshair.lineWidth % 2 ? 0.5 : 0;
 
                 ctx.strokeStyle = c.color;
@@ -146,13 +85,13 @@ The plugin also adds four public methods:
                 ctx.lineJoin = "round";
 
                 ctx.beginPath();
-                if (c.mode.indexOf("x") != -1) {
-                    var drawX = Math.floor(crosshair.x) + adj;
+                if (c.mode.indexOf("x") !== -1) {
+                    var drawX = Math.floor(pixelPos.x) + adj;
                     ctx.moveTo(drawX, 0);
                     ctx.lineTo(drawX, plot.height());
                 }
-                if (c.mode.indexOf("y") != -1) {
-                    var drawY = Math.floor(crosshair.y) + adj;
+                if (c.mode.indexOf("y") !== -1) {
+                    var drawY = Math.floor(pixelPos.y) + adj;
                     ctx.moveTo(0, drawY);
                     ctx.lineTo(plot.width(), drawY);
                 }
@@ -160,17 +99,12 @@ The plugin also adds four public methods:
             }
             ctx.restore();
         });
-
-        plot.hooks.shutdown.push(function (plot, eventHolder) {
-            eventHolder.unbind("mouseout", onMouseOut);
-            eventHolder.unbind("mousemove", onMouseMove);
-        });
     }
     
     $.plot.plugins.push({
         init: init,
         options: options,
         name: 'crosshair',
-        version: '1.0'
+        version: '1.1'
     });
-})(jQuery);
+}(jQuery));


### PR DESCRIPTION
Hi Richard,

Here is a fix for the bug I mentioned recently where the cross-hair on the graph ends up in the wrong place if you resize the window.

The off-the-shelf plugin that I used to draw the cross-hair was remembering the position in _pixels_, then using those stored coordinates each time the graph was repainted. To cope with resizing, I now store the position in axis coordinates instead and convert to pixels immediately before drawing.

I've also removed a few functions from the plugin that I don't need.
